### PR TITLE
Docker container for Flexwin

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:jammy
+
+RUN apt-get update && \
+  DEBIAN_FRONTEND='noninteractive' \
+  DEBCONF_NONINTERACTIVE_SEEN='true' \
+  apt-get install --yes \
+    gfortran \
+    build-essential \
+    git
+
+RUN useradd \
+  --create-home \
+  flexwin_user
+
+USER flexwin_user
+
+WORKDIR /home/flexwin_user
+
+RUN git clone 'https://github.com/geodynamics/flexwin.git'; cd flexwin; cd ttimes_mod; make -f make_gfortran; make -f make_gfortran install;
+
+ENV SACHOME="/home/flexwin_user/work/sac"
+ENV PATH="/home/flexwin_user/flexwin:${PATH}"

--- a/docker/readme.md
+++ b/docker/readme.md
@@ -1,0 +1,14 @@
+This container hosts the source code for Flexwin. Flexwin relies on libraries from the SAC software package which can only be distributed by IRIS and so cannot be included in the geodynamics/flexwin docker image. Because the SAC libraries cannot be included in the docker image, it is up to the user to obtain a copy of SAC and compile flexwin within the container.
+
+docker run -it --rm -v $HOME/flexwin:/home/flexwin_user/work geodynamics/flexwin
+
+This command will start the flexwin docker image and give you terminal access. Any changes made in the /home/flexwin/work directory will be reflected on the host machine at home/flexwin.
+
+In order to compile flexwin, make sure that a copy of the SAC library exists in the /home/flexwin/work directory. The easiest way to do this is:
+
+    contact IRIS in order to download a copy of SAC for linux using this form: ds.iris.edu/ds/nodes/dmc/forms/sac/
+    place your (unzipped) copy of SAC into /home/flexwin on the host machine
+
+Flexwin relies on the environment variable SACHOME in order to find the SAC library during compilation. By default, this container sets SACHOME to /home/flexwin_user/work/sac, which is equivalent to home/flexwin on the host machine. If you want to place your copy of SAC into a directory in the container other than /home/flexwin_user/work/sac, you will need to make sure that the SACHOME variable points to your chosen location within the container.
+
+Once SAC is available within the container, you should be able to follow the instructions in the README located in the root directory in order to compile Flexwin.

--- a/make_gfortran
+++ b/make_gfortran
@@ -4,6 +4,7 @@ CFLAGS= ${OPT}
 
 TAULIBDIR=ttimes_mod
 SACLIBDIR=${SACHOME}/lib
+%.o: %.mod
 
 LIBS= -lsacio -lsac -ltau -lm
 

--- a/seismo_subs.f90
+++ b/seismo_subs.f90
@@ -513,7 +513,7 @@
 
 !----------------------------------------------------------------------
 
-  subroutine bandpass(x, n, delta_t, x_filt)
+  subroutine bandpass_seismo_subs(x, n, delta_t, x_filt)
   use seismo_variables
   implicit none
 
@@ -543,7 +543,7 @@
 
   deallocate(x_sngl)
 
-  end subroutine bandpass
+  end subroutine bandpass_seismo_subs
 
 !----------------------------------------------------------------------
   subroutine prepare_bp_seis
@@ -553,8 +553,8 @@
   ! make filtered seismograms
   obs_lp(:) = 0.
   synt_lp(:) = 0.
-  call bandpass(obs,npts,dt,obs_lp)
-  call bandpass(synt,npts,dt,synt_lp)
+  call bandpass_seismo_subs(obs,npts,dt,obs_lp)
+  call bandpass_seismo_subs(synt,npts,dt,synt_lp)
 
   end subroutine prepare_bp_seis
 


### PR DESCRIPTION
I had to edit the Makefile and one source file (seismo_subs.f90) slightly in order to get the software to compile. I added a line to the makefile to prevent the compiler from trying to use m2c to open .mod files. The file seismo_subs contained a function called "bandpass" which has the same name as a function from the SAC library. I wonder if the "bandpass" function was added to SAC more recently which caused this name collision problem. Changing the name of the function in seismo_subs from "bandpass" to "bandpass_seismo_subs" allowed the program to compile, but I don't know if this the best solution. Still, the test data worked properly after I was able to compile flexwin.